### PR TITLE
updated to include http protocol in url

### DIFF
--- a/m4i_atlas_core/api/core/handle_request.py
+++ b/m4i_atlas_core/api/core/handle_request.py
@@ -28,7 +28,7 @@ async def handle_request(
         "atlas.credentials.password"
     )
 
-    url = f"http://{atlas_url}/{path}"
+    url = f"{atlas_url}/{path}"
 
     auth = None
     headers: dict = {}

--- a/scripts/config.sample.py
+++ b/scripts/config.sample.py
@@ -1,4 +1,4 @@
 config = {
-    "atlas.server.url": "YOUR_SERVER_URL (e.g. atlas.models4insight.com/api/atlas)",
+    "atlas.server.url": "YOUR_SERVER_URL (e.g. http://atlas.models4insight.com/api/atlas)",
     "data.dictionary.path": "YOUR_DATA_DICTIONARY_PATH"
 }


### PR DESCRIPTION
**What:**
Updated the config "atlas.server.url" to include the http protocol

**Why:** 
the http protocol was hard coded in handel request on the m4i_atlas_core to make it more dynamic it can now be adjusted by changing it in the config.

**Where atlas.server.url is used:**

m4i_atlas_core: only in handel request (where we want to change it)

m4i_flink_tasks: Only in config -- "atlas.server.url": os.getenv('ATLAS_EXTERNAL_URL') **
 - ATLAS_EXTERNAL_URL in helm update to include http protocol

docker-python-rest: Only in Config

m4i_data_dictionary_io : only in config and readme


**Actions:**

Flink helm deployment env var- - ATLAS_EXTERNAL_URL update to include http protocol

You need to update the config file from
atlas.models4insight.com/api/atlas
to
http://atlas.models4insight.com/api/atlas
